### PR TITLE
Preserve separator format

### DIFF
--- a/src/types/notes.ts
+++ b/src/types/notes.ts
@@ -1,4 +1,9 @@
 export interface NoteSection {
   speaker: string;
   text: string;
+  format?: {
+    separatorBefore?: string;
+    speakerPrefix?: string;
+    speakerSuffix?: string;
+  };
 }

--- a/src/utils/notes.ts
+++ b/src/utils/notes.ts
@@ -1,50 +1,82 @@
 import { DEFAULT_SPEAKER_VALUE } from "../constants/speaker";
 import type { NoteSection } from "../types/notes";
 
-const SECTION_DIVIDER_PATTERN = /^[ \t]*-{3,}[ \t]*$/;
-const SPEAKER_TAG_PATTERN = /^[ \t]*\[([^\]]*)\][ \t]*$/;
-const WHITESPACE_ONLY_PATTERN = /^[ \t]*$/;
+const DEFAULT_SECTION_SEPARATOR = "\n---\n";
+const SECTION_DIVIDER_PATTERN = /^[ \t]*-{3,}[ \t]*(?:\n)?$/;
+const SPEAKER_TAG_PATTERN = /^((?:[ \t]*\n)*[ \t]*)\[([^\]\n]*)\]([ \t]*)(?:\n|$)/;
+const LEADING_WHITESPACE_PATTERN = /^[ \t]*/;
+const TRAILING_WHITESPACE_PATTERN = /[ \t]*$/;
+
+interface RawNoteSection {
+  separatorBefore?: string;
+  text: string;
+}
 
 export const normalizeNotes = (text: string): string => text.replace(/\r\n|\r/g, "\n");
 
-function splitRawSections(text: string): string[] {
-  const lines = text.split("\n");
-  const sections = [""];
+function splitRawSections(text: string): RawNoteSection[] {
+  const sections: RawNoteSection[] = [];
+  let currentText = "";
+  let separatorBefore: string | undefined;
+  let lineStart = 0;
 
-  for (const line of lines) {
+  while (lineStart < text.length) {
+    const newlineIndex = text.indexOf("\n", lineStart);
+    const lineEnd = newlineIndex === -1 ? text.length : newlineIndex + 1;
+    const line = text.slice(lineStart, lineEnd);
+
     if (SECTION_DIVIDER_PATTERN.test(line)) {
-      sections.push("");
-      continue;
+      let separator = line;
+      if (currentText.endsWith("\n")) {
+        currentText = currentText.slice(0, -1);
+        separator = `\n${separator}`;
+      }
+
+      sections.push({
+        separatorBefore,
+        text: currentText,
+      });
+      separatorBefore = separator;
+      currentText = "";
+    } else {
+      currentText = `${currentText}${line}`;
     }
 
-    const current = sections[sections.length - 1];
-    sections[sections.length - 1] = current ? `${current}\n${line}` : line;
+    lineStart = lineEnd;
   }
+
+  sections.push({
+    separatorBefore,
+    text: currentText,
+  });
 
   return sections;
 }
 
-function parseSection(rawSection: string): NoteSection {
-  const lines = rawSection.split("\n");
-  let speakerLineIndex = 0;
-
-  while (speakerLineIndex < lines.length && WHITESPACE_ONLY_PATTERN.test(lines[speakerLineIndex])) {
-    speakerLineIndex += 1;
-  }
-
-  const speakerMatch =
-    speakerLineIndex < lines.length ? lines[speakerLineIndex].match(SPEAKER_TAG_PATTERN) : null;
+function parseSection(rawSection: RawNoteSection): NoteSection {
+  const speakerMatch = rawSection.text.match(SPEAKER_TAG_PATTERN);
+  const format = rawSection.separatorBefore ? { separatorBefore: rawSection.separatorBefore } : {};
 
   if (!speakerMatch) {
     return {
       speaker: DEFAULT_SPEAKER_VALUE,
-      text: rawSection,
+      text: rawSection.text,
+      ...(Object.keys(format).length ? { format } : {}),
     };
   }
 
+  const speakerText = speakerMatch[2];
+  const leadingSpeakerWhitespace = speakerText.match(LEADING_WHITESPACE_PATTERN)?.[0] || "";
+  const trailingSpeakerWhitespace = speakerText.match(TRAILING_WHITESPACE_PATTERN)?.[0] || "";
+
   return {
-    speaker: speakerMatch[1].trim() || DEFAULT_SPEAKER_VALUE,
-    text: lines.slice(speakerLineIndex + 1).join("\n"),
+    speaker: speakerText.trim() || DEFAULT_SPEAKER_VALUE,
+    text: rawSection.text.slice(speakerMatch[0].length),
+    format: {
+      ...format,
+      speakerPrefix: `${speakerMatch[1]}[${leadingSpeakerWhitespace}`,
+      speakerSuffix: `${trailingSpeakerWhitespace}]${speakerMatch[3]}`,
+    },
   };
 }
 
@@ -70,13 +102,18 @@ export const getEffectiveSpeaker = (sections: NoteSection[], index: number): str
 };
 
 export const formatNotes = (sections: NoteSection[]): string => {
-  return sections
-    .map((section) => {
-      if (section.speaker !== DEFAULT_SPEAKER_VALUE) {
-        return section.text ? `[${section.speaker}]\n${section.text}` : `[${section.speaker}]`;
-      }
+  return sections.reduce((notes, section, index) => {
+    const separator = index > 0 ? section.format?.separatorBefore || DEFAULT_SECTION_SEPARATOR : "";
 
-      return section.text;
-    })
-    .join("\n---\n");
+    if (section.speaker !== DEFAULT_SPEAKER_VALUE) {
+      const speakerPrefix = section.format?.speakerPrefix || "[";
+      const speakerSuffix = section.format?.speakerSuffix || "]";
+      const speakerTag = `${speakerPrefix}${section.speaker}${speakerSuffix}`;
+      const sectionText = section.text ? `${speakerTag}\n${section.text}` : speakerTag;
+
+      return `${notes}${separator}${sectionText}`;
+    }
+
+    return `${notes}${separator}${section.text}`;
+  }, "");
 };


### PR DESCRIPTION
This PR preserves the whitespaces around `-` section separators and `[`, `]` voice tags, as well as the number of `-` the separator has.

Addresses issue #23